### PR TITLE
added impressum

### DIFF
--- a/src/default.template
+++ b/src/default.template
@@ -128,6 +128,7 @@
 
       <!-- FOOTER -->
       <div class="footer">
+      		<div><p style="text-align:center;"><a href="{relocatable: impressum.html}">Imprint/Impressum</a></div></p>
           <div class="nav1">
               <ul>
                   <li><a href="{relocatable: documentation/about/index.html}">About Rock</a></li>

--- a/src/impressum.page
+++ b/src/impressum.page
@@ -1,0 +1,35 @@
+---
+page_title: Impressum
+title: "Rock: the Robot Construction Kit"
+rock_page_style: centered
+template: index.template
+---
+
+<div>
+	<h2>Inhaltlicher Kontakt</h2>
+	Jakob.Schwendner&#064;dfki.de<br/>
+	Thomas.Roehr&#064;dfki.de<br/>
+	sylvain.joyeux&#064;m4x.org
+
+    <h2>Deutsches Forschungszentrum f&uuml;r K&uuml;nstliche Intelligenz GmbH</h2>
+    <p>
+	<b>Standort Bremen<br />Robotics Innovation Center<br /></b>
+	Robert-Hooke-Str. 1<br />
+	28359 Bremen<br />
+	Telefon: +49 (0)421 / 178 45 - 0<br />
+	Telefax: +49 (0)421 / 178 45 - 4150<br />
+	E-Mail: robotik&#064;dfki.de</a><br />
+	Leitung: Prof. Dr. Frank Kirchner
+    </p>
+   
+    <p>
+    <b>Gesch&auml;ftsf&uuml;hrung:</b><br />
+    Prof. Dr. Dr. h.c. mult. Wolfgang Wahlster (Vorsitzender),<br />
+    Dr. Walter Olthoff<br /><br />
+    Vorsitzender des Aufsichtsrates:<br />
+    Prof. Dr. h.c. Hans A. Aukes<br /><br />
+    Amtsgericht Kaiserslautern<br />
+    HRB 2313<br />
+    ID-Nummer DE 148 646 973
+    </p>
+</div>

--- a/src/impressum.page
+++ b/src/impressum.page
@@ -6,6 +6,12 @@ template: index.template
 ---
 
 <div>
+
+	<p>
+    <b>This page gives contact information about the people maintaining the web site and the organization hosting it.</b><br/><br/>
+    Rock is an Open Source project, it is maintained by many more people with different affiliations.
+    </p>  
+
 	<h2>Inhaltlicher Kontakt</h2>
 	Jakob.Schwendner&#064;dfki.de<br/>
 	Thomas.Roehr&#064;dfki.de<br/>


### PR DESCRIPTION
rock-robotics.org is hosted by the DFKI and needs an Impressum (by german law).

I added it in the footer, but I am still unsure about the content:

* I tried to make clear that the DFKI is not the maintainer of rock and is only hosting the site.
* Persons responsible for the contents are currently the owners of "rock-core" which can finally merge changes to the page (imo)
* it is not final, that the DFKI is willing to be named there, this is still TBD, but I wanted to start the discussion early.

@doudou @2maz @jakobs : Is it ok for you to mention you here?